### PR TITLE
debug: revert to Webrick for dev.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,57 +1,49 @@
 source 'https://rubygems.org'
 
-gem 'pry'
-gem 'unicorn-rails'
-gem "font-awesome-rails"
-gem 'httparty'
-gem 'figaro'
-gem 'octokit'
-gem 'bcrypt'
-gem 'cancancan'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.4'
 # Use postgresql as the database for Active Record
 gem 'pg'
+
+# >>>>>>>>>>>>>>>>>>>>>>>>>
+# remaining gems are sorted alphabetically
+gem 'bcrypt' # Use ActiveModel has_secure_password
+gem 'cancancan'
+# Use CoffeeScript for .coffee assets and views
+gem 'coffee-rails', '~> 4.1.0'
+gem 'figaro'
+gem 'font-awesome-rails'
+gem 'httparty'
+# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
+gem 'jbuilder', '~> 2.0'
+# Use jquery as the JavaScript library
+gem 'jquery-rails'
+gem 'octokit'
+# Redcarpet is a Ruby library for Markdown processing that smells like butterflies and popcorn.
+gem 'redcarpet'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
-# Use CoffeeScript for .coffee assets and views
-gem 'coffee-rails', '~> 4.1.0'
-# See https://github.com/rails/execjs#readme for more supported runtimes
-# gem 'therubyracer', platforms: :ruby
 
-# Use jquery as the JavaScript library
-gem 'jquery-rails'
-# Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'jbuilder', '~> 2.0'
-# bundle exec rake doc:rails generates the API under doc/api.
-gem 'sdoc', '~> 0.4.0', group: :doc
 
-# Redcarpet is a Ruby library for Markdown processing that smells like butterflies and popcorn.
-gem 'redcarpet'
-
-# Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
-
-# Use Unicorn as the app server
-# gem 'unicorn'
-
-# Use Capistrano for deployment
-# gem 'capistrano-rails', group: :development
+group :production do
+  # WORKAROUND: had difficulties debugging with unicorn, reverted to Webrick for dev
+  gem 'unicorn-rails'
+end
 
 group :development, :test do
-  # Call 'byebug' or 'binding.pry' anywhere in the code to stop execution and get a debugger console
+  # Call 'binding.pry', 'debugger', or 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'pry-byebug'
   gem 'rspec-rails', '~> 3.0'
+  # Access an IRB console on exception pages or by using <%= console %> in views
+  gem 'web-console', '~> 2.0'
 end
 
 group :development do
-  # Access an IRB console on exception pages or by using <%= console %> in views
-  gem 'web-console', '~> 2.0'
-
+  # bundle exec rake doc:rails generates the API under doc/api.
+  gem 'sdoc', '~> 0.4.0', group: :doc
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-  gem 'spring'
+  # gem 'spring'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,7 +165,6 @@ GEM
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
     slop (3.6.0)
-    spring (1.4.0)
     sprockets (3.4.0)
       rack (> 1, < 3)
     sprockets-rails (2.3.3)
@@ -207,14 +206,12 @@ DEPENDENCIES
   jquery-rails
   octokit
   pg
-  pry
   pry-byebug
   rails (= 4.2.4)
   redcarpet
   rspec-rails (~> 3.0)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
-  spring
   uglifier (>= 1.3.0)
   unicorn-rails
   web-console (~> 2.0)


### PR DESCRIPTION
- sort gems
- had difficulties getting unicorn to support pry/debugger, so reverted to webrick for dev.
- comment out “spring”