### PR TITLE
hotfix: ensure migration works locally

### DIFF
--- a/db/migrate/20151104040728_remove_excess_memberships.rb
+++ b/db/migrate/20151104040728_remove_excess_memberships.rb
@@ -6,7 +6,9 @@ class RemoveExcessMemberships < ActiveRecord::Migration
 
     garoot = User.named("garoot")
     garoot.destroy if garoot
-    Group.at_path("ga").add_owner("jshawl")
-    Group.at_path("ga").add_owner("bmartinowich")
+
+    # Add specific owners, need condition for env's that don't have these users (dev/test)
+    Group.at_path("ga").add_owner("jshawl") if User.named("jshawl")
+    Group.at_path("ga").add_owner("bmartinowich") if User.named("bmartinowich")
   end
 end


### PR DESCRIPTION
- RemoveExcessMemberships was adding users, that didn't exist locally, to groups.

Note: this should not affect Production (please think about that too).  In fact, this migration has already run successfully on production.  