### PR TITLE
removeExcessMigration fixed

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -41,6 +41,7 @@ class Group < Tree
   def self.at_path path
     path = path.split("_")
     group = Group.find_by(title: path[0])
+    return false if !group
     path.each_with_index do |title, i|
       next if i == 0
       group = group.children.find_by(title: path[i])

--- a/db/migrate/20151104040728_remove_excess_memberships.rb
+++ b/db/migrate/20151104040728_remove_excess_memberships.rb
@@ -1,14 +1,20 @@
 class RemoveExcessMemberships < ActiveRecord::Migration
   def change
-    Group.at_path("ga").memberships.where(is_owner: true).delete_all
-    Group.at_path("ga_wdi").memberships.delete_all
-    Group.at_path("ga_wdi_dc").memberships.delete_all
+    ["ga", "ga_wdi", "ga_wdi_dc"].each do |path|
+      group = Group.at_path(path)
+      next if !group
+      memberships = group.memberships
+      if path == "ga"
+        memberships.where(is_owner: true).delete_all
+        # Add specific owners, need condition for env's that don't have these users (dev/test)
+        group.add_owner("jshawl") if User.named("jshawl")
+        group.add_owner("bmartinowich") if User.named("bmartinowich")
+      else
+        memberships.delete_all
+      end
+    end
 
     garoot = User.named("garoot")
     garoot.destroy if garoot
-
-    # Add specific owners, need condition for env's that don't have these users (dev/test)
-    Group.at_path("ga").add_owner("jshawl") if User.named("jshawl")
-    Group.at_path("ga").add_owner("bmartinowich") if User.named("bmartinowich")
   end
 end


### PR DESCRIPTION
Migration was referencing groups/users that only exist when using production data dump.