### PR TITLE
Re-enable /users/is_authorized (as “is-registered), for Installfest.

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,11 @@
 class UsersController < ApplicationController
 
-  skip_before_action :authenticate, except: [:show]
+  skip_before_action :authenticate, only: [:create,
+    :gh_authorize, :gh_authenticate,
+    :is_registered?,
+    :new,
+    :sign_in, :sign_in!
+  ]
 
   def orphans
     @users = User.all.select{|u| u.groups.count < 1}
@@ -87,7 +92,7 @@ class UsersController < ApplicationController
     end
   end
 
-  def is_authorized?
+  def is_registered?
     render json: User.exists?(username: params[:github_username])
   end
 
@@ -123,7 +128,9 @@ class UsersController < ApplicationController
   end
 
   def gh_authenticate
-    if(!params[:code]) then redirect_to action: :gh_authorize end
+    if(!params[:code])
+      redirect_to action: :gh_authorize
+    end
     github = Github.new(ENV)
     session[:access_token] = github.get_access_token(params[:code])
     gh_user_info = github.user_info

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
     resources :observations, only: [:create]
     put 'refresh_memberships', on: :member
     get "orphans", to: "users#orphans", on: :collection
-    get "is_authorized", action: :is_authorized?
+    get "is-registered", action: :is_registered?, on: :collection
   end
 
   resources :assignments, only: [:show, :update, :destroy] do

--- a/spec/requests/installfest_spec.rb
+++ b/spec/requests/installfest_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe "Installfest", :type => :request do
+  it "requires un-authenticated access to /users/is_registered endpoint" do
+    get "/users/is-registered"
+    expect(response).to_not be_redirect
+  end
+
+  it "returns true (as json) for registered user" do
+    get "/users/is-registered", format: :json, github_username: "mattscilipoti"
+    expect(response).to be_success
+    expect(response.body).to eq("true")
+  end
+
+  it "returns false (as json) for unregistered user" do
+    get "/users/is-registered", format: :json, github_username: "unknown_user"
+    expect(response).to be_success
+    expect(response.body).to eq("false")
+  end
+end


### PR DESCRIPTION
- added spec
- White list actions in UsersController
- rename is-autohorized to is-registered.  “is-authorized” meant student has authorized WDI via GitHub.  I think “is-registered” is more appropriate.