### PR TITLE
Rspec configure using suggested/provided settings

### DIFF
--- a/spec/models/github_spec.rb
+++ b/spec/models/github_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Github' do
+RSpec.describe 'Github' do
   before {skip}
   it "has an access token" do
     g = Github.new(nil, ENV['token'])
@@ -9,7 +9,7 @@ describe 'Github' do
   it "has a repo" do
     g = Github.new(nil, ENV['token'])
     repo = g.repo("ga-dc/js-calculator")
-    expect(repo).to be 
+    expect(repo).to be
   end
   it "has issues" do
     g = Github.new(nil, ENV['token'])

--- a/spec/requests/installfest_spec.rb
+++ b/spec/requests/installfest_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe "Installfest", :type => :request do
   end
 
   it "returns true (as json) for registered user" do
-    get "/users/mattscilipoti/is_registered", format: :json
+    FactoryGirl.create(:user, username: "RegisteredUser")
+    get "/users/registereduser/is_registered", format: :json
     expect(response).to be_success
     expect(response.body).to eq("true")
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -72,7 +72,7 @@ RSpec.configure do |config|
   #   - http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax
   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
   #   - http://myronmars.to/n/dev-blog/2014/05/notable-changes-in-rspec-3#new__config_option_to_disable_rspeccore_monkey_patching
-  # config.disable_monkey_patching!
+  config.disable_monkey_patching!
 
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,7 +54,7 @@ RSpec.configure do |config|
 
   # The settings below are suggested to provide a good initial experience
   # with RSpec, but feel free to customize to your heart's content.
-=begin
+
   # These two settings work together to allow you to limit a spec run
   # to individual examples or groups you care about by tagging them with
   # `:focus` metadata. When nothing is tagged with `:focus`, all examples
@@ -65,14 +65,14 @@ RSpec.configure do |config|
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
+  config.example_status_persistence_file_path = "tmp/rspec_examples.txt"
 
   # Limits the available syntax to the non-monkey patched syntax that is
   # recommended. For more details, see:
   #   - http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax
   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
   #   - http://myronmars.to/n/dev-blog/2014/05/notable-changes-in-rspec-3#new__config_option_to_disable_rspeccore_monkey_patching
-  config.disable_monkey_patching!
+  # config.disable_monkey_patching!
 
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an
@@ -87,7 +87,7 @@ RSpec.configure do |config|
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
-  config.profile_examples = 10
+  config.profile_examples = 2
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing
@@ -100,5 +100,5 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
-=end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -101,4 +101,9 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 
+  # disable "should" syntax
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+
 end


### PR DESCRIPTION
- Randomizes specs.
- Can now use `rspec —-only-failures` and focus tag on spec.
- Lists 2 slowest examples
- disable_monkey_patches