### PR TITLE
Link to memberships for admins, include tag list on memberships page.

### DIFF
--- a/app/views/cohorts/show.html.erb
+++ b/app/views/cohorts/show.html.erb
@@ -28,7 +28,7 @@
 
     <p>Admins:
       <% @admins.each do |user| %>
-        <%= link_to user.name || user.username, user_path(user) %>
+        <%= link_to user.name, user.memberships.find_by(cohort: @cohort) %>
         <%= link_to("(x)", toggle_admin_membership_path(user.memberships.find_by(cohort: @cohort)), method: :post, data: {confirm: "Are you sure you want to remove this admin?"}) if @is_admin %>,
       <% end %>
     </p>

--- a/app/views/memberships/show.html.erb
+++ b/app/views/memberships/show.html.erb
@@ -3,6 +3,10 @@
   <h2 class='membership'><%= link_to @user.name, @user %> in <%= link_to @membership.cohort.name, @membership.cohort %></h2>
 </div>
 
+<% if can? :manage, @membership.cohort %>
+  <%= tag_list @membership %>
+<% end %>
+
 <% if @is_current_user  %>
   <% @current_attendances.each do |attendance| %>
     <%= form_tag self_take_attendance_path(attendance), method: :put do  %>


### PR DESCRIPTION
This allows us to easily reach our own membership pages, and allows admins to manage tags for any user on their membership page, admins included. 