### PR TITLE
Changed Observation status integers

### DIFF
--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -89,8 +89,9 @@ class Membership < ActiveRecord::Base
   end
 
   def update_average_observations
-    average = self.observations.where.not(status:3).average(:status).to_f.round(2)
-    self.update!(average_observations: self.observations.any? ? average : nil)
+    obz = self.observations.where.not(status: Observation.statuses[:neutral])
+    average = obz.any? ? obz.average(:status).to_f.round(2) : 0
+    self.update!(average_observations: average)
     return average
   end
 

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -5,7 +5,7 @@ class Observation < ActiveRecord::Base
   has_one :cohort, through: :membership
   has_one :user,  through: :membership
 
-  enum status: [:red, :yellow, :green, :neutral]
+  enum status: [:neutral, :red, :yellow, :green]
 
   after_save do
     self.membership.update_average_observations

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -7,6 +7,10 @@ class Observation < ActiveRecord::Base
 
   enum status: [:neutral, :red, :yellow, :green]
 
+  before_save do
+    self.status = 0 if self.status.nil?
+  end
+
   after_save do
     self.membership.update_average_observations
   end

--- a/db/migrate/20160322171539_make_neutral_observations_zero.rb
+++ b/db/migrate/20160322171539_make_neutral_observations_zero.rb
@@ -1,0 +1,14 @@
+class MakeNeutralObservationsZero < ActiveRecord::Migration
+  def change
+    Observation.all.each do |observation|
+      next if !observation.membership || !observation.user
+      status_in = observation.read_attribute("status")
+      if status_in === 3 || status_in.nil?
+        status_out = 0
+      else
+        status_out = status_in + 1
+      end
+      observation.update(status: status_out)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160318191715) do
+ActiveRecord::Schema.define(version: 20160322171539) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -77,6 +77,14 @@ ActiveRecord::Schema.define(version: 20160318191715) do
     t.integer  "cohort_id"
   end
 
+  create_table "groups", force: :cascade do |t|
+    t.string   "title"
+    t.string   "category"
+    t.integer  "parent_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "locations", force: :cascade do |t|
     t.string   "name"
     t.string   "short_name"

--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe Observation do
+  before(:all) do
+    @cohort = Cohort.create
+    @user = User.create(name: "test", username: "obzmodeltest")
+    @membership = @cohort.add_member(@user)
+  end
+  it "has a default status of 0" do
+    o = @membership.observations.create(body: "test")
+    expect(o.read_attribute("status")).to be(0)
+  end
+  it "changes nil statuses to 0" do
+    o = @membership.observations.create(body: "test", status: "green")
+    o.update(status: nil)
+    expect(o.read_attribute("status")).to be(0)
+  end
+end


### PR DESCRIPTION
Now they better match Submissions and Attendances, which have 0 as "unmarked". For Observations, "neutral" changes from 3 to 0.