### PR TITLE
Refactored coloring of statuses and percents (Contingent on standardizing Obz statuses)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,37 +17,38 @@ module ApplicationHelper
     end
   end
 
-  def color_of_percent input, type = :good
-    # can't do calculations on nil values
-    return "" if input.nil?
-
-    # if the input is a 'bad' value, flip and scale the value accordingly.
-    # e.g. a good value would be %HW complete, and 75% would be green
-    #
-    # but a bad value might be "% absent", and 10% would be yellow
-    input = (100 - (input* 3)) if type == :bad
-
-    case input
-    when -1000...25
-      return "status_very_bad"
-    when 25...50
-      return "status_bad"
-    when 50...75
-      return "status_mediocre"
-    when 75..1000
-      return "status_good"
+  def color_of input, options = {}
+    # These are options that can optionally be passed in when the method is called
+    greenest_possible_input = options[:green]
+    reddest_possible_input  = options[:red]
+    type_of_output          = options[:type]
+    # HSL is a color method like RGB and CMYK. It stands for "Hue, Saturation, Lightness"
+    # If h is 120 it's green; 240 is blue; 360 and 0 are red
+    hsl_green_value = 120
+    hsl_red_value   = 0
+    if input.is_a? Numeric
+      greenest_possible_input  ||= 100
+      reddest_possible_input   ||= 0
+    else # elsif input is a record, like submission, attendance, observation, etc
+      greenest_possible_input  ||= (input.class.statuses.count - 1)
+      reddest_possible_input   ||= 1
+      input = input.read_attribute("status")
+      input = nil if (input == 0)
     end
-  end
-
-  def color_of_status input
-    case input
-    when "red"
-      return "status_very_bad"
-    when "yellow"
-      return "status_mediocre"
-    when "green"
-      return "status_good"
+    return "" if (input.nil?)
+    input_range = (greenest_possible_input - reddest_possible_input)
+    input_as_percentage = (input - reddest_possible_input).to_f / (input_range)
+    # How "green" is the input?
+    hsl_color_value = hsl_green_value * input_as_percentage
+    if hsl_color_value > hsl_green_value
+      hsl_color_value = [hsl_color_value, hsl_green_value].min
+    else # Makes sure the color doesn't go past green or red
+      hsl_color_value = [hsl_color_value, hsl_red_value].max
     end
+    hsl_string = "hsl(#{hsl_color_value},100%,90%)"
+    return hsl_color_value if (type_of_output === "int")
+    return hsl_string if (type_of_output === "hsl_string")
+    return "style='background-color:#{hsl_string};'".html_safe
   end
 
   def percent_of collection, value

--- a/app/views/memberships/_row.html.erb
+++ b/app/views/memberships/_row.html.erb
@@ -12,7 +12,8 @@
     <% end %>
     <% if can? :see_observations, membership %>
       <% if membership.average_observations %>
-        <td data-sort-field="avg_ob" class="<%= color_of_percent((membership.average_observations/2) * 100 )%>"><%= membership.average_observations %></td>
+        <td data-sort-field="avg_ob" <%= color_of(membership.average_observations, {green: 2, red: 0})%>>
+          <%= membership.average_observations %></td>
       <% else %>
         <td>N/A</td>
       <% end %>

--- a/app/views/memberships/_row_performance_cells.html.erb
+++ b/app/views/memberships/_row_performance_cells.html.erb
@@ -1,12 +1,12 @@
 <% present      = membership.percent_from_status(:attendances, :present) + membership.percent_from_status(:attendances, :tardy) %>
 <% tardy        = membership.attendances.where(status: Attendance.statuses[:tardy]).count %>
 <% hw_complete  = membership.percent_from_status(:submissions, :complete) %>
-<td data-sort-field="tardy">
+<td data-sort-field="tardy" <%= color_of(tardy, {green: 0, red: 5})%>>
   <%= tardy %>
 </td>
-<td data-sort-field="present" class="<%= color_of_percent(present, :good) %>">
+<td data-sort-field="present" <%= color_of(present, {green: 100, red: 80}) %>>
   <%= "#{present}%" || "N/A" %>
 </td>
-<td data-sort-field="hw_complete" class="<%= color_of_percent(hw_complete, :good) %>">
+<td data-sort-field="hw_complete" <%= color_of(hw_complete, {green: 100, red: 80}) %>>
   <%= "#{hw_complete}%" || "N/A" %>
 </td>

--- a/app/views/observations/_observation.html.erb
+++ b/app/views/observations/_observation.html.erb
@@ -1,4 +1,4 @@
-<div class="observation <%= color_of_status(observation.status) %>" id="observations-<%= observation.id %>">
+<div class="observation" <%= color_of(observation) %> id="observations-<%= observation.id %>">
   <%= markdown(observation.body) %>
   <p><small>By
     <%= link_to observation.admin.username, user_path(observation.admin) %> for

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,93 @@
+require "rails_helper"
+
+RSpec.describe ApplicationHelper do
+  describe "#color_of" do
+    # These are defined using the HSL color spectrum
+    let(:red){ 0 }
+    let(:yellow){ 60 }
+    let(:green){ 120 }
+    let(:orange){ 48 }
+    context "when passed a submission or attendance" do
+      before(:all) do
+        u = User.create(name: "test")
+        c = Cohort.create
+        @sub = c.add_member(u).submissions.create
+        @options = {type: "int"}
+      end
+      it "returns empty string for unmarked" do
+        @sub.update!(status: "unmarked")
+        expect(color_of(@sub, @options)).to eq("")
+      end
+      it "returns red for missing" do
+        @sub.update!(status: "missing")
+        expect(color_of(@sub, @options)).to eq(red)
+      end
+      it "returns yellow for incomplete" do
+        @sub.update!(status: "incomplete")
+        expect(color_of(@sub, @options)).to eq(yellow)
+      end
+      it "returns green for complete" do
+        @sub.update!(status: "complete")
+        expect(color_of(@sub, @options)).to eq(green)
+      end
+    end
+    context "when passed a number of tardies" do
+      before(:all) do
+        @options = {type: "int", green: 0, red: 5}
+      end
+      it "returns green for 0" do
+        expect(color_of(0, @options)).to eq(green)
+      end
+      it "returns red for 5" do
+        expect(color_of(5, @options)).to eq(red)
+      end
+    end
+    context "when passed a percent" do
+      before(:all) do
+        @options = {type: "int"}
+      end
+      it "returns green for 100" do
+        expect(color_of(100, @options)).to eq(green)
+      end
+      it "returns yellow for 50" do
+        expect(color_of(50, @options)).to eq(yellow)
+      end
+      it "returns red for 0" do
+        expect(color_of(0, @options)).to eq(red)
+      end
+    end
+    context "when passed a percent for submissions or attendance" do
+      before(:all) do
+        @options = {type: "int", green: 100, red: 80}
+      end
+      it "returns green for 100%" do
+        expect(color_of(100, @options)).to eq(green)
+      end
+      it "returns yellow for 90%" do
+        expect(color_of(90, @options)).to eq(yellow)
+      end
+      it "returns red for 80%" do
+        expect(color_of(80, @options)).to eq(red)
+      end
+      it "returns red for 70%" do
+        expect(color_of(70, @options)).to eq(red)
+      end
+    end
+    context "when passed an average observation" do
+      before(:all) do
+        @options = {type: "int", green: Observation.statuses[:green], red: Observation.statuses[:red]}
+        @cohort = Cohort.create
+        @user = User.create(name: "obztest", username: "obztest")
+        @m = @cohort.add_member(@user)
+      end
+      it "returns orange for 2 red, 2 yellow, 1 green observation" do
+        {red: 2, yellow: 2, green: 1}.each do |color, quantity|
+          quantity.times do
+            @m.observations.create!(status: color, body: "Test")
+          end
+        end
+        expect(color_of(@m.average_observations, @options)).to eq(orange)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- A single "#color_of" helper method that takes a variety of inputs
- Colors are rendered with `style` tags on HSL scale instead of with CSS classes
- Specs included
- We won't talk about how much math this took the first time around