### PR TITLE
Metrics: Sandi Metz rules via sandi_meter, outputs to /metrics/sandi_meter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 /config/application.yml
 /public/assets
 
+# generated metrics
+/public/metrics

--- a/Gemfile
+++ b/Gemfile
@@ -34,19 +34,20 @@ group :production do
 end
 
 group :development, :test do
-  gem 'ffaker'
-  gem 'shoulda'
   gem 'awesome_print'
   gem 'capybara'
   gem 'database_cleaner'
-  gem 'launchy' # for capybara, save_and_open_page
+  gem 'ffaker'
   gem "factory_girl_rails" # for generating sample data for tests
+  gem 'launchy' # for capybara, save_and_open_page
   gem 'newrelic_rpm' # http://newrelic.com/ruby
   gem 'poltergeist' # for headless browser tests via capybara
   gem 'pry-byebug' # Call 'binding.pry', 'debugger', or 'byebug' to debug
   gem 'quiet_assets'
   gem 'rspec-rails', '~> 3.0'
+  gem 'sandi_meter'
   gem 'selenium-webdriver'
+  gem 'shoulda'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,7 @@ GEM
     mime-types (2.99.1)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
+    mixlib-cli (1.5.0)
     multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
@@ -189,7 +190,11 @@ GEM
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
     rubyzip (1.2.0)
-    sass (3.4.21)
+    sandi_meter (1.2.0)
+      json
+      launchy
+      mixlib-cli
+    sass (3.4.19)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
       sass (~> 3.1)
@@ -290,6 +295,7 @@ DEPENDENCIES
   rails (= 4.2.4)
   redcarpet
   rspec-rails (~> 3.0)
+  sandi_meter
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   select2-rails

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,3 +1,7 @@
+every :day, :at => '1am' do
+  rake "metrics:generate"
+end
+
 every :day, :at => '10am' do
   rake "attendance:mark_absent"
 end

--- a/lib/tasks/metrics.rake
+++ b/lib/tasks/metrics.rake
@@ -1,0 +1,28 @@
+namespace :metrics do
+  def logger
+    require 'logger'
+    logger = Logger.new(Rails.root.join("log/metrics.log"), "monthly")
+  end
+
+  desc "Generate all metrics"
+  task :generate do
+    # expects all metrics to have :generate tasks
+    metrics = %w(sandi_meter)
+    metrics.each do |metric|
+      metric_rake_task = "metrics:#{metric}:generate"
+      Rake::Task[metric_rake_task].invoke
+    end
+  end
+
+  namespace :sandi_meter do
+    desc "Generates/updates html pages at /metrics/sandi_meter"
+    task :generate do
+      # mms: using CLI because I could not find easy way to access anaylzer, for rails -> html, via code
+      output_path = Rails.root.join('public/metrics/sandi_meter')
+      message = "Generating sandi_meter metrics at #{output_path}"
+      logger.info message
+      puts message
+      `sandi_meter --graph -q --output-path "#{output_path}"`
+    end
+  end
+end

--- a/lib/tasks/metrics.rake
+++ b/lib/tasks/metrics.rake
@@ -15,14 +15,23 @@ namespace :metrics do
   end
 
   namespace :sandi_meter do
-    desc "Generates/updates html pages at /metrics/sandi_meter"
+    sandi_pages_path = Rails.root.join('public/metrics/sandi_meter')
+
+    desc "Generates/updates html pages for /metrics/sandi_meter"
     task :generate do
       # mms: using CLI because I could not find easy way to access anaylzer, for rails -> html, via code
-      output_path = Rails.root.join('public/metrics/sandi_meter')
-      message = "Generating sandi_meter metrics at #{output_path}"
+      message = "Generating sandi_meter metrics at #{sandi_pages_path}"
       logger.info message
-      puts message
-      `sandi_meter --graph -q --output-path "#{output_path}"`
+      # puts message
+      `sandi_meter --graph --quiet --output-path "#{sandi_pages_path}"`
+    end
+
+    desc "Clean html pages at #{sandi_pages_path}"
+    task :clean do
+      message = "Removing sandi_meter pages #{sandi_pages_path}"
+      logger.info message
+      # puts message
+      FileUtils.rm_rf(sandi_pages_path)
     end
   end
 end

--- a/lib/tasks/sandi_meter.rake
+++ b/lib/tasks/sandi_meter.rake
@@ -1,0 +1,9 @@
+namespace :sandi_meter do
+  desc "Generates/updates html pages at /metrics/sandi_meter"
+  task :generate do
+    # mms: using CLI because I could not find easy way to access anaylzer, for rails -> html, via code
+    output_path = Rails.root.join('public/metrics/sandi_meter')
+    puts "Generating #{output_path}"
+    `sandi_meter --graph -q --output-path "#{output_path}"`
+  end
+end

--- a/lib/tasks/sandi_meter.rake
+++ b/lib/tasks/sandi_meter.rake
@@ -1,9 +1,0 @@
-namespace :sandi_meter do
-  desc "Generates/updates html pages at /metrics/sandi_meter"
-  task :generate do
-    # mms: using CLI because I could not find easy way to access anaylzer, for rails -> html, via code
-    output_path = Rails.root.join('public/metrics/sandi_meter')
-    puts "Generating #{output_path}"
-    `sandi_meter --graph -q --output-path "#{output_path}"`
-  end
-end

--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,16 @@ unicorn, the application server.
 
 # Troubleshooting
 
+## Metrics
+
+- `rake -T metrics`
+- cron job updates nightly, see config/schedule.rb
+
+### Sandi Metz rules
+
+- sandi_meter outputs to "/metrics/sandi_meter"
+- https://github.com/makaroni4/sandi_meter
+
 ## NewRelic
 
 New Relic monitors the app and provides metrics.  They are available in development mode (/newrelic) and production (rpm.newrelic.com).  It is recommended that you [install newrelic-sysmond on the servers](https://rpm.newrelic.com/accounts/1130222/servers/get_started).

--- a/spec/requests/metrics_spec.rb
+++ b/spec/requests/metrics_spec.rb
@@ -1,9 +1,26 @@
 require 'rails_helper'
+require 'rake'
 
 RSpec.describe "Metrics", :type => :request do
-  let(:url_path) { "/metrics/sandi_meter" }
+  def require_rake_file(rake_file)
+    Rake.application = Rake::Application.new
+    loaded_files_excluding_current_rake_file = []
+    # puts "Requiring rake_file: #{rake_file}"
+    Rake.application.rake_require(rake_file, [Rails.root.join("lib/tasks").to_s], loaded_files_excluding_current_rake_file)
+  end
+
   describe "sandi_meter" do
-    it "requires un-authenticated access to /metrics/sandi_meter endpoint" do
+    let(:url_path)  { "/metrics/sandi_meter" }
+
+    before(:all) do
+      require_rake_file("metrics")
+      # clean up
+      Rake::Task['metrics:sandi_meter:clean'].invoke
+      # generate
+      Rake::Task['metrics:sandi_meter:generate'].invoke
+    end
+
+    it "requires un-authenticated access to endpoint" do
       get url_path
       expect(response).to_not be_redirect
     end

--- a/spec/requests/metrics_spec.rb
+++ b/spec/requests/metrics_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe "Metrics", :type => :request do
+  let(:url_path) { "/metrics/sandi_meter" }
+  describe "sandi_meter" do
+    it "requires un-authenticated access to /metrics/sandi_meter endpoint" do
+      get url_path
+      expect(response).to_not be_redirect
+    end
+
+    it "contains the sandi_meter html report" do
+      get url_path
+      expect(response.body).to match(/Sandi Metz rules/i)
+    end
+  end
+end


### PR DESCRIPTION
Using html output from sand_meter:  https://github.com/makaroni4/sandi_meter

- `rake -T metrics`
- cron job updates nightly, see config/schedule.rb
- sandi_meter outputs to "/metrics/sandi_meter"
