### PR TITLE
Brakeman: security checker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ group :development, :test do
 end
 
 group :development do
+  gem 'brakeman', :require => false
   gem 'web-console', '~> 2.0' # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'sdoc', '~> 0.4.0', group: :doc   # bundle exec rake doc:rails generates the API under doc/api.
   # gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,16 @@ GEM
     bcrypt (3.1.11)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
+    brakeman (3.2.1)
+      erubis (~> 2.6)
+      haml (>= 3.0, < 5.0)
+      highline (>= 1.6.20, < 2.0)
+      ruby2ruby (~> 2.3.0)
+      ruby_parser (~> 3.8.1)
+      safe_yaml (>= 1.0)
+      sass (~> 3.0)
+      slim (>= 1.3.6, < 4.0)
+      terminal-table (~> 1.4)
     builder (3.2.2)
     byebug (8.2.2)
     cancancan (1.13.1)
@@ -89,8 +99,11 @@ GEM
       railties (>= 3.2, < 5.1)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
+    haml (4.0.7)
+      tilt
     has_secure_token (1.0.0)
       activerecord (>= 3.0)
+    highline (1.7.8)
     httparty (0.13.7)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
@@ -189,7 +202,13 @@ GEM
       rspec-mocks (~> 3.4.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
+    ruby2ruby (2.3.0)
+      ruby_parser (~> 3.1)
+      sexp_processor (~> 4.0)
+    ruby_parser (3.8.1)
+      sexp_processor (~> 4.1)
     rubyzip (1.2.0)
+    safe_yaml (1.0.4)
     sandi_meter (1.2.0)
       json
       launchy
@@ -213,6 +232,7 @@ GEM
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
+    sexp_processor (4.7.0)
     shoulda (3.5.0)
       shoulda-context (~> 1.0, >= 1.0.1)
       shoulda-matchers (>= 1.4.1, < 3.0)
@@ -222,6 +242,9 @@ GEM
     simple_form (3.2.1)
       actionpack (> 4, < 5.1)
       activemodel (> 4, < 5.1)
+    slim (3.0.6)
+      temple (~> 0.7.3)
+      tilt (>= 1.3.3, < 2.1)
     slop (3.6.0)
     sprockets (3.5.2)
       concurrent-ruby (~> 1.0)
@@ -230,6 +253,8 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    temple (0.7.6)
+    terminal-table (1.5.2)
     thin (1.6.4)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -270,6 +295,7 @@ DEPENDENCIES
   ancestry
   awesome_print
   bcrypt
+  brakeman
   cancancan
   capybara
   coderay
@@ -308,4 +334,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -53,3 +53,8 @@
   color:#fff;
   margin-bottom:.5em;
 }
+
+#metrics {
+  font-size: 1.2em;
+  list-style-type: disc !important;
+}

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -1,0 +1,5 @@
+class MetricsController < ApplicationController
+  def index
+    @metrics = Metric.names
+  end
+end

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -1,0 +1,7 @@
+require 'logger'
+
+class Metric
+  def self.names
+    %w(brakeman sandi_meter).sort
+  end
+end

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -1,5 +1,3 @@
-require 'logger'
-
 class Metric
   def self.names
     %w(brakeman sandi_meter).sort

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,7 +51,7 @@
     <div class="links">
       <a class="fa fa-code-fork" href="https://github.com/ga-dc/garnet" target="_blank"> GitHub</a>
       <a class="fa fa-ship" href="http://ci.wdidc.org/job/garnet/lastBuild/" target="_blank"> Jenkins</a>
-      <%= link_to "Metrics", "/metrics/sandi_meter", class: 'fa fa-bar-chart', target: "_blank" %>
+      <%= link_to "Metrics", "/metrics", class: 'fa fa-bar-chart', target: "_blank" %>
     </div>
   </footer>
   <%= javascript_include_tag 'application' %>

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -1,0 +1,9 @@
+<h1>Metrics</h1>
+
+<ul id="metrics">
+<% @metrics.each do |metric_name| %>
+  <li>
+    <%= link_to metric_name, "#{metrics_path}/#{metric_name}" %>
+  </li>
+<% end %>
+</ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   resources :courses
   resources :locations
 
+  get "/metrics", to: "metrics#index", as: 'metrics'
+
   root to: "dashboards#to_do"
 
   get  '/sign_in',  to: 'sessions#new',     as: :sign_in

--- a/lib/tasks/metrics.rake
+++ b/lib/tasks/metrics.rake
@@ -1,3 +1,4 @@
+require_relative "../../app/models/metric"
 namespace :metrics do
   def logger
     require 'logger'
@@ -40,6 +41,7 @@ namespace :metrics do
       cmd += " --quiet" unless verbose
 
       logger.info "Generating brakeman: #{cmd}"
+      puts "Generating brakeman..." if verbose
       `#{cmd}`
     end
   end

--- a/lib/tasks/metrics.rake
+++ b/lib/tasks/metrics.rake
@@ -30,10 +30,17 @@ namespace :metrics do
     end
 
     desc "Generates/updates brakeman html report"
-    task :generate do
-      FileUtils.mkdir(brakeman_path)
+    task :generate, [:verbose] do |t, args|
+      args.with_defaults(verbose: 'true')
+      verbose = (args[:verbose] == 'true') ? true : false
+
+      FileUtils.mkdir(brakeman_path) unless Dir.exists?(brakeman_path)
       output_file = brakeman_path.join('index.html')
-      `brakeman --output #{output_file}`
+      cmd = "brakeman --output #{output_file}"
+      cmd += " --quiet" unless verbose
+
+      logger.info "Generating brakeman: #{cmd}"
+      `#{cmd}`
     end
   end
 
@@ -41,12 +48,17 @@ namespace :metrics do
     sandi_pages_path = metrics_path.join('sandi_meter')
 
     desc "Generates/updates html pages for /metrics/sandi_meter"
-    task :generate do
+    task :generate, [:verbose] do |t, args|
+      args.with_defaults(verbose: 'true')
+      verbose = (args[:verbose] == 'true') ? true : false
+
       # mms: using CLI because I could not find easy way to access anaylzer, for rails -> html, via code
-      message = "Generating sandi_meter metrics at #{sandi_pages_path}"
+      cmd = %Q(sandi_meter --quiet --graph --output-path "#{sandi_pages_path}")
+      # cmd += " --details" if verbose
+      message = "Generating sandi_meter metrics: #{cmd}"
       logger.info message
-      # puts message
-      `sandi_meter --graph --quiet --output-path "#{sandi_pages_path}"`
+      puts message if verbose
+      `#{cmd}`
 
       # update assets for rails public dir
       index_file = sandi_pages_path.join('index.html')

--- a/lib/tasks/metrics.rake
+++ b/lib/tasks/metrics.rake
@@ -4,18 +4,41 @@ namespace :metrics do
     logger = Logger.new(Rails.root.join("log/metrics.log"), "monthly")
   end
 
+  def metrics_path
+    Rails.root.join('public/metrics/')
+  end
+
+
   desc "Generate all metrics"
   task :generate do
     # expects all metrics to have :generate tasks
-    metrics = %w(sandi_meter)
-    metrics.each do |metric|
-      metric_rake_task = "metrics:#{metric}:generate"
+    Metric.names.each do |metric_name|
+      metric_rake_task = "metrics:#{metric_name}:generate"
       Rake::Task[metric_rake_task].invoke
     end
   end
 
+  namespace :brakeman do
+    brakeman_path = metrics_path.join('brakeman')
+
+    desc "Clean html pages at #{brakeman_path}"
+    task :clean do
+      message = "Removing brakeman pages #{brakeman_path}"
+      logger.info message
+      # puts message
+      FileUtils.rm_rf(brakeman_path)
+    end
+
+    desc "Generates/updates brakeman html report"
+    task :generate do
+      FileUtils.mkdir(brakeman_path)
+      output_file = brakeman_path.join('index.html')
+      `brakeman --output #{output_file}`
+    end
+  end
+
   namespace :sandi_meter do
-    sandi_pages_path = Rails.root.join('public/metrics/sandi_meter')
+    sandi_pages_path = metrics_path.join('sandi_meter')
 
     desc "Generates/updates html pages for /metrics/sandi_meter"
     task :generate do

--- a/readme.md
+++ b/readme.md
@@ -86,9 +86,14 @@ unicorn, the application server.
 - `rake -T metrics`
 - cron job updates nightly, see config/schedule.rb
 
+### Brakeman: Security checker
+
+- outputs to "public/metrics/brakeman"
+- https://github.com/presidentbeef/brakeman
+
 ### Sandi Metz rules
 
-- sandi_meter outputs to "/metrics/sandi_meter"
+- sandi_meter outputs to "public/metrics/sandi_meter"
 - https://github.com/makaroni4/sandi_meter
 
 ## NewRelic

--- a/spec/requests/metrics_spec.rb
+++ b/spec/requests/metrics_spec.rb
@@ -9,6 +9,28 @@ RSpec.describe "Metrics", :type => :request do
     Rake.application.rake_require(rake_file, [Rails.root.join("lib/tasks").to_s], loaded_files_excluding_current_rake_file)
   end
 
+  describe "brakeman" do
+    let(:url_path)  { "/metrics/brakeman" }
+
+    before(:all) do
+      require_rake_file("metrics")
+      # clean up
+      Rake::Task['metrics:brakeman:clean'].invoke
+      # generate
+      Rake::Task['metrics:brakeman:generate'].invoke
+    end
+
+    it "requires un-authenticated access to endpoint" do
+      get url_path
+      expect(response).to_not be_redirect
+    end
+
+    it "contains the brakeman html report" do
+      get url_path
+      expect(response.body).to match(/Brakeman Report/i)
+    end
+  end
+
   describe "sandi_meter" do
     let(:url_path)  { "/metrics/sandi_meter" }
 

--- a/spec/requests/metrics_spec.rb
+++ b/spec/requests/metrics_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Metrics", :type => :request do
       # clean up
       Rake::Task['metrics:brakeman:clean'].invoke
       # generate
-      Rake::Task['metrics:brakeman:generate'].invoke
+      Rake::Task['metrics:brakeman:generate'].invoke('false')
     end
 
     it "requires un-authenticated access to endpoint" do
@@ -39,7 +39,7 @@ RSpec.describe "Metrics", :type => :request do
       # clean up
       Rake::Task['metrics:sandi_meter:clean'].invoke
       # generate
-      Rake::Task['metrics:sandi_meter:generate'].invoke
+      Rake::Task['metrics:sandi_meter:generate'].invoke('false')
     end
 
     it "requires un-authenticated access to endpoint" do


### PR DESCRIPTION
Adds brakeman to /metrics.
- outputs to "public/metrics/brakeman"
- https://github.com/presidentbeef/brakeman

To test manually, use rake tasks: `rake -T metrics`


Note: immediately after pushing, you will receive "No route matches [GET] "/metrics/brakeman" because the report as not been generated (public/metrics/brakeman/index.html).  You can either generate the report, via the rake task, or wait for the nightly cron/rake task.